### PR TITLE
Revert "Update webpack to the latest version 🚀"

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "stylelint-webpack-plugin": "^0.5.1",
     "surge": "^0.18.0",
     "url-loader": "0.5.7",
-    "webpack": "2.2.1",
+    "webpack": "1.14.0",
     "webpack-cleanup-plugin": "^0.4.1",
     "webpack-dev-server": "1.16.2"
   },


### PR DESCRIPTION
Reverts tongrhj/rainbow-rex-2#2

Tests don't rely on webpack, so they give misleading results when dependencies are updated